### PR TITLE
Add repo support to Agent class

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -48,4 +48,13 @@ def test_conversation_save_load(env_setup, tmp_path):
     new_agent.load_conversation()
     
     assert len(new_agent.history) == 1
-    assert new_agent.history.messages[0]["content"] == "Test message" 
+    assert new_agent.history.messages[0]["content"] == "Test message"
+
+def test_add_repo_with_github_repo(env_setup):
+    agent = Agent("claude-2.1", memory_enabled=True)
+    
+    # Test add_repo method with a real GitHub repository
+    agent.add_repo(repo_url="https://github.com/xihajun/llm_dialog_manager/archive/refs/heads/main.zip")
+    
+    # Check if .env.example file content is in the repo_content
+    assert any(".env.example" in content for content in agent.repo_content)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -10,6 +10,14 @@ def test_agent_initialization(env_setup):
     with pytest.raises(ValueError):
         Agent("invalid-model")
 
+    # Test add_repo method
+    agent.add_repo("https://github.com/some/repo/archive/refs/heads/main.zip")
+    assert "some content from the repo" in agent.history.messages[-1]["content"]
+
+    # Test add_repo method with username and repo name
+    agent.add_repo(repo_url="", username="someuser", repo_name="somerepo")
+    assert "some content from the repo" in agent.history.messages[-1]["content"]
+
 def test_agent_message_handling(env_setup):
     agent = Agent("claude-2.1", memory_enabled=True)
     
@@ -19,6 +27,14 @@ def test_agent_message_handling(env_setup):
     
     assert len(agent.history) == 2
     assert agent.history.messages[-1]["role"] == "user"
+
+    # Test add_repo method
+    agent.add_repo("https://github.com/some/repo/archive/refs/heads/main.zip")
+    assert "some content from the repo" in agent.history.messages[-1]["content"]
+
+    # Test add_repo method with username and repo name
+    agent.add_repo(repo_url="", username="someuser", repo_name="somerepo")
+    assert "some content from the repo" in agent.history.messages[-1]["content"]
 
 def test_conversation_save_load(env_setup, tmp_path):
     agent = Agent("claude-2.1")


### PR DESCRIPTION
Related to #1

Add support for adding a GitHub repository to the `Agent` class.

* Add `add_repo` method to the `Agent` class in `llm_dialog_manager/agent.py` to update the `system_prompt` attribute with the provided repository URL.
* Update the `__init__` method of the `Agent` class to include the `repo_content` attribute.
* Add logic to `add_repo` method to accept username and repository name as input.
* Save repository content as a buffer and update it.
* Add repository content to the user message and empty the buffer using `self.repo_content.pop()`.

* Add tests for the `add_repo` method in `tests/test_agent.py`.
  * Test `add_repo` method with direct repository URL.
  * Test `add_repo` method with username and repository name.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/xihajun/llm_dialog_manager/pull/2?shareId=322eb943-6308-4b78-8746-afcbf9309022).